### PR TITLE
Use write instead of puts when returning the IP of an instance.

### DIFF
--- a/bin/ec2
+++ b/bin/ec2
@@ -30,7 +30,7 @@ when "ssh"
   instance = instances[ARGV[1]]
   system("sh -c \"ssh -t admin@#{instance} 'sudo -i'\"")
 when "ip"
-  STDOUT.puts instances[ARGV[1]]
+  STDOUT.write instances[ARGV[1]]
 else
   help
 end


### PR DESCRIPTION
I use this command mostly to get the IP of an instance and do something
with it in other scripts.

If I use 'puts' the script returns the '\n' and that makes parsing the
response a little bit harder.
